### PR TITLE
Fix: refactor default template logic to prevent multiple comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Checklist
-        uses: PokaInc/pr-template-action@v1.1.0
+        uses: PokaInc/pr-template-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           template_dir: '.the/path/to/your/templates/'

--- a/dist/index.js
+++ b/dist/index.js
@@ -798,36 +798,28 @@ async function run() {
             return;
         }
 
-        // Everything's good, comment on the PR!
-        mapping.split(';').forEach(rule => {
-            let [name, patterns] = rule.split('=');
-            let filename = `${name}.md`;
+        let foundPrefix;
 
-            patterns.split(',').forEach(pattern => {
-                if (branch.startsWith(pattern)) {
-                    if (!templates.includes(filename)) {
-                        core.setFailed(`Could not find template: ${filename}!`);
-                        return;
-                    }
-
-                    create_comment(octokit, issue, template_dir, filename);
-
-                    return;
+        if (mapping) {
+            const mappingArr = mapping.split(';').map((curr) => {
+                const [name, prefixes] = curr.split('=');
+                return {
+                    file: name,
+                    prefixes: prefixes.split(',')
                 }
             });
-        });
 
-        // No pattern matched, let's check for the default template
-        if (default_template) {
-            let filename = `${default_template}.md`;
-
-            if (!templates.includes(filename)) {
-                core.setFailed(`Could not find template: ${filename}!`);
-                return;
-            }
-
-            create_comment(octokit, issue, template_dir, filename);
+            foundPrefix = mappingArr.find((item) => item.prefixes.some((prefix) => branch.startsWith(prefix)))
         }
+
+        const filename = `${foundPrefix ? foundPrefix.file : default_template}.md`;
+
+        if (!templates.includes(filename)) {
+            core.setFailed(`Could not find template: ${filename}!`);
+            return;
+        }
+
+        create_comment(octokit, issue, template_dir, filename);
     } catch (error) {
         core.setFailed(error.message);
     }

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ async function run() {
             foundPrefix = mappingArr.find((item) => item.prefixes.some((prefix) => branch.startsWith(prefix)))
         }
 
-        const filename = `${foundPrefix?.file || default_template}.md`
+        const filename = `${foundPrefix ? foundPrefix.file : default_template}.md`;
 
         if (!templates.includes(filename)) {
             core.setFailed(`Could not find template: ${filename}!`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-template-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Branch name based PR checklists",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In #15, I introduced an issue where:

- if you had a default template defined
- pushed a branch that matched an existing pattern

Then you could end up with duplicated comments on your PR, as seen on this very PR... 👇 
